### PR TITLE
Spelling fixes for The Lurking Horror

### DIFF
--- a/cs.zil
+++ b/cs.zil
@@ -4950,7 +4950,7 @@ and it's roughly pentagonal." CR>)
 		      (<P? POUR (COKE NITROGEN) *>
 		       <COND (<FSET? ,PENTAGRAM ,RMUNGBIT>
 			      <TELL
-"The pentagram is now almostly entirely effaced." CR>)
+"The pentagram is now almost entirely effaced." CR>)
 			     (ELSE
 			      <TELL
 CTHE ,PRSO " pours on the ground, spreading towards the lines of the


### PR DESCRIPTION
These are the spelling fixes for The Lurking Horror from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.